### PR TITLE
feat($search): include Search on Category and Tag Layout´s

### DIFF
--- a/lib/components/PostsFilter.vue
+++ b/lib/components/PostsFilter.vue
@@ -1,78 +1,84 @@
 <template>
-  <div class="posts">
-    <div class="main-div">
-      <div
-        class="filter-categories"
-        v-if="categoryFilter"
-      >
-        <h3 class="filter-categories">
-          <RouterLink to="/posts/categories/">
-            {{ $themeConfig.lang.categories }}
-          </RouterLink>
-        </h3>
+  <div class="main-div">
+    <div
+      v-if="categories"
+      class="filter-categories"
+    >
+      <h3>
+        <RouterLink to="/posts/categories/">
+          {{ $themeConfig.lang.categories }}
+        </RouterLink>
+      </h3>
 
-        <PostsFilterCategories v-model="filterCategory" />
-      </div>
-
-      <div
-        class="filter-tags"
-        v-if="tagFilter"
-      >
-        <h3 class="filter-tags">
-          <RouterLink to="/posts/tags/">
-            {{ $themeConfig.lang.tags }}
-          </RouterLink>
-        </h3>
-
-        <PostsFilterTags v-model="filterTags" />
-      </div>
-
-      <div
-        class="filter-search"
-        v-if="search"
-      >
-        <h3 class="filter-search">
-          {{ $themeConfig.lang.search }}
-        </h3>
-
-        <PostsFilterSearch v-model="filterSearch" />
-      </div>
+      <PostsFilterCategories v-model="filterCategory" />
     </div>
 
-    <div class="main-div">
-      <TransitionFadeSlide>
-        <div
-          v-if="filteredPosts.length ===0"
-          class="no-posts"
-        >
-          {{ $themeConfig.lang.noRelatedPosts }}
-        </div>
+    <div
+      v-if="tags"
+      class="filter-tags"
+    >
+      <h3>
+        <RouterLink to="/posts/tags/">
+          {{ $themeConfig.lang.tags }}
+        </RouterLink>
+      </h3>
 
-        <PostsList
-          v-else
-          :posts="filteredPosts"
-        />
-      </TransitionFadeSlide>
+      <PostsFilterTags v-model="filterTags" />
+    </div>
+
+    <div
+      v-if="search"
+      class="filter-search"
+    >
+      <h3>
+        {{ $themeConfig.lang.search }}
+      </h3>
+
+      <PostsFilterSearch v-model="filterSearch" />
     </div>
   </div>
 </template>
 
 <script>
-import PostsList from '../components/PostsList.vue'
 import PostsFilterCategories from '../components/PostsFilterCategories.vue'
 import PostsFilterTags from '../components/PostsFilterTags.vue'
 import PostsFilterSearch from '../components/PostsFilterSearch.vue'
-import TransitionFadeSlide from '../components/TransitionFadeSlide.vue'
 
 export default {
-  name: 'PostsMain',
+  name: 'PostsFilter',
 
   components: {
-    PostsList,
     PostsFilterCategories,
     PostsFilterTags,
     PostsFilterSearch,
-    TransitionFadeSlide,
+  },
+
+  props: {
+    posts: {
+      type: Array,
+      required: false,
+      default: null,
+    },
+    categories: {
+      type: Boolean,
+      required: false,
+      default: true,
+    },
+    tags: {
+      type: Boolean,
+      required: false,
+      default: true,
+    },
+    search: {
+      type: Boolean,
+      required: false,
+      default: true,
+    },
+    value: {
+      type: Array,
+      required: false,
+      default: () => [],
+    },
   },
 
   data () {
@@ -83,38 +89,15 @@ export default {
     }
   },
 
-  props: {
-    posts: {
-      type: Array,
-      required: false,
-      default: null,
-    },
-    search: {
-      type: Boolean,
-      required: false,
-      default: true,
-    },
-    categoryFilter: {
-      type: Boolean,
-      required: false,
-      default: true,
-    },
-    tagFilter: {
-      type: Boolean,
-      required: false,
-      default: true,
-    },
-  },
-
   computed: {
     filteredPosts () {
       let filteredPosts = this.posts || this.$posts
 
-      if (this.filterCategory) {
+      if (this.categories && this.filterCategory) {
         filteredPosts = filteredPosts.filter(p => p.category === this.filterCategory)
       }
 
-      if (this.filterTags.length !== 0) {
+      if (this.tags && this.filterTags.length !== 0) {
         filteredPosts = filteredPosts.filter(p => {
           const postTags = p.tags
           for (const tag of this.filterTags) {
@@ -126,7 +109,7 @@ export default {
         })
       }
 
-      if (this.filterSearch !== '') {
+      if (this.search && this.filterSearch !== '') {
         const searchString = this.filterSearch.toLowerCase().trim()
         const match = item => {
           if (typeof item === 'string') {
@@ -151,6 +134,15 @@ export default {
       return filteredPosts
     },
   },
+
+  watch: {
+    filteredPosts: {
+      immediate: true,
+      handler (val) {
+        this.$emit('input', val)
+      },
+    },
+  },
 }
 </script>
 
@@ -161,11 +153,4 @@ export default {
 .filter-tags
   a
     color $textColor
-</style>
-
-<style lang="stylus" scoped>
-@require '~@theme/styles/variables'
-
-.no-posts
-  color $grayTextColor
 </style>

--- a/lib/components/PostsList.vue
+++ b/lib/components/PostsList.vue
@@ -1,16 +1,28 @@
 <template>
-  <TransitionFadeSlide
-    tag="div"
-    class="posts-list"
-    direction="x"
-    group
-  >
-    <PostsListItem
-      v-for="post in listPosts"
-      :key="post.path"
-      :post="post"
-    />
-  </TransitionFadeSlide>
+  <div class="main-div posts-list">
+    <TransitionFadeSlide>
+      <div
+        v-if="listPosts.length === 0"
+        class="no-posts"
+        key="no-posts"
+      >
+        {{ $themeConfig.lang.noRelatedPosts }}
+      </div>
+
+      <TransitionFadeSlide
+        v-else
+        tag="div"
+        direction="x"
+        group
+      >
+        <PostsListItem
+          v-for="post in listPosts"
+          :key="post.path"
+          :post="post"
+        />
+      </TransitionFadeSlide>
+    </TransitionFadeSlide>
+  </div>
 </template>
 
 <script>
@@ -40,3 +52,10 @@ export default {
   },
 }
 </script>
+
+<style lang="stylus" scoped>
+@require '~@theme/styles/variables'
+
+.no-posts
+  color $grayTextColor
+</style>

--- a/lib/components/PostsList.vue
+++ b/lib/components/PostsList.vue
@@ -1,44 +1,21 @@
 <template>
-  <div class="postlist">
-    <div class="main-div">
-      <h3 class="filter-search">
-        {{ $themeConfig.lang.search }}
-      </h3>
-
-      <PostsFilterSearch v-model="filterSearch" />
-    </div>
-
-    <div class="main-div">
-      <TransitionFadeSlide>
-        <div
-          v-if="listPosts.length ===0"
-          class="no-posts"
-        >
-          {{ $themeConfig.lang.noRelatedPosts }}
-        </div>
-
-        <TransitionFadeSlide
-          v-else
-          tag="div"
-          class="posts-list"
-          direction="x"
-          group
-        >
-          <PostsListItem
-            v-for="post in listPosts"
-            :key="post.path"
-            :post="post"
-          />
-        </TransitionFadeSlide>
-      </TransitionFadeSlide>
-    </div>
-  </div>
+  <TransitionFadeSlide
+    tag="div"
+    class="posts-list"
+    direction="x"
+    group
+  >
+    <PostsListItem
+      v-for="post in listPosts"
+      :key="post.path"
+      :post="post"
+    />
+  </TransitionFadeSlide>
 </template>
 
 <script>
 import TransitionFadeSlide from './TransitionFadeSlide.vue'
 import PostsListItem from './PostsListItem.vue'
-import PostsFilterSearch from '../components/PostsFilterSearch.vue'
 
 export default {
   name: 'PostsList',
@@ -46,13 +23,6 @@ export default {
   components: {
     TransitionFadeSlide,
     PostsListItem,
-    PostsFilterSearch,
-  },
-
-  data () {
-    return {
-      filterSearch: '',
-    }
   },
 
   props: {
@@ -65,39 +35,8 @@ export default {
 
   computed: {
     listPosts () {
-      const posts = this.posts || this.$posts
-
-      if (this.filterSearch !== '') {
-        const searchString = this.filterSearch.toLowerCase().trim()
-        const match = item => {
-          if (typeof item === 'string') {
-            return item.toLowerCase().includes(searchString)
-          }
-
-          if (Array.isArray(item)) {
-            return item.map(i => match(i)).includes(true)
-          }
-
-          return false
-        }
-        return posts.filter(p =>
-          match(p.title) ||
-          match(p.excerpt) ||
-          match(p.frontmatter.description) ||
-          match(p.tags) ||
-          match(p.category)
-        )
-      }
-
-      return posts
+      return this.posts || this.$posts
     },
   },
 }
 </script>
-
-<style lang="stylus" scoped>
-@require '~@theme/styles/variables'
-
-.no-posts
-  color $grayTextColor
-</style>

--- a/lib/components/PostsList.vue
+++ b/lib/components/PostsList.vue
@@ -1,21 +1,44 @@
 <template>
-  <TransitionFadeSlide
-    tag="div"
-    class="posts-list"
-    direction="x"
-    group
-  >
-    <PostsListItem
-      v-for="post in listPosts"
-      :key="post.path"
-      :post="post"
-    />
-  </TransitionFadeSlide>
+  <div class="postlist">
+    <div class="main-div">
+      <h3 class="filter-search">
+        {{ $themeConfig.lang.search }}
+      </h3>
+
+      <PostsFilterSearch v-model="filterSearch" />
+    </div>
+
+    <div class="main-div">
+      <TransitionFadeSlide>
+        <div
+          v-if="listPosts.length ===0"
+          class="no-posts"
+        >
+          {{ $themeConfig.lang.noRelatedPosts }}
+        </div>
+
+        <TransitionFadeSlide
+          v-else
+          tag="div"
+          class="posts-list"
+          direction="x"
+          group
+        >
+          <PostsListItem
+            v-for="post in listPosts"
+            :key="post.path"
+            :post="post"
+          />
+        </TransitionFadeSlide>
+      </TransitionFadeSlide>
+    </div>
+  </div>
 </template>
 
 <script>
 import TransitionFadeSlide from './TransitionFadeSlide.vue'
 import PostsListItem from './PostsListItem.vue'
+import PostsFilterSearch from '../components/PostsFilterSearch.vue'
 
 export default {
   name: 'PostsList',
@@ -23,6 +46,13 @@ export default {
   components: {
     TransitionFadeSlide,
     PostsListItem,
+    PostsFilterSearch,
+  },
+
+  data () {
+    return {
+      filterSearch: '',
+    }
   },
 
   props: {
@@ -35,8 +65,39 @@ export default {
 
   computed: {
     listPosts () {
-      return this.posts || this.$posts
+      const posts = this.posts || this.$posts
+
+      if (this.filterSearch !== '') {
+        const searchString = this.filterSearch.toLowerCase().trim()
+        const match = item => {
+          if (typeof item === 'string') {
+            return item.toLowerCase().includes(searchString)
+          }
+
+          if (Array.isArray(item)) {
+            return item.map(i => match(i)).includes(true)
+          }
+
+          return false
+        }
+        return posts.filter(p =>
+          match(p.title) ||
+          match(p.excerpt) ||
+          match(p.frontmatter.description) ||
+          match(p.tags) ||
+          match(p.category)
+        )
+      }
+
+      return posts
     },
   },
 }
 </script>
+
+<style lang="stylus" scoped>
+@require '~@theme/styles/variables'
+
+.no-posts
+  color $grayTextColor
+</style>

--- a/lib/components/PostsMain.vue
+++ b/lib/components/PostsMain.vue
@@ -1,0 +1,171 @@
+<template>
+  <div class="posts">
+    <div class="main-div">
+      <div
+        class="filter-categories"
+        v-if="categoryFilter"
+      >
+        <h3 class="filter-categories">
+          <RouterLink to="/posts/categories/">
+            {{ $themeConfig.lang.categories }}
+          </RouterLink>
+        </h3>
+
+        <PostsFilterCategories v-model="filterCategory" />
+      </div>
+
+      <div
+        class="filter-tags"
+        v-if="tagFilter"
+      >
+        <h3 class="filter-tags">
+          <RouterLink to="/posts/tags/">
+            {{ $themeConfig.lang.tags }}
+          </RouterLink>
+        </h3>
+
+        <PostsFilterTags v-model="filterTags" />
+      </div>
+
+      <div
+        class="filter-search"
+        v-if="search"
+      >
+        <h3 class="filter-search">
+          {{ $themeConfig.lang.search }}
+        </h3>
+
+        <PostsFilterSearch v-model="filterSearch" />
+      </div>
+    </div>
+
+    <div class="main-div">
+      <TransitionFadeSlide>
+        <div
+          v-if="filteredPosts.length ===0"
+          class="no-posts"
+        >
+          {{ $themeConfig.lang.noRelatedPosts }}
+        </div>
+
+        <PostsList
+          v-else
+          :posts="filteredPosts"
+        />
+      </TransitionFadeSlide>
+    </div>
+  </div>
+</template>
+
+<script>
+import PostsList from '../components/PostsList.vue'
+import PostsFilterCategories from '../components/PostsFilterCategories.vue'
+import PostsFilterTags from '../components/PostsFilterTags.vue'
+import PostsFilterSearch from '../components/PostsFilterSearch.vue'
+import TransitionFadeSlide from '../components/TransitionFadeSlide.vue'
+
+export default {
+  name: 'PostsMain',
+
+  components: {
+    PostsList,
+    PostsFilterCategories,
+    PostsFilterTags,
+    PostsFilterSearch,
+    TransitionFadeSlide,
+  },
+
+  data () {
+    return {
+      filterTags: [],
+      filterCategory: null,
+      filterSearch: '',
+    }
+  },
+
+  props: {
+    posts: {
+      type: Array,
+      required: false,
+      default: null,
+    },
+    search: {
+      type: Boolean,
+      required: false,
+      default: true,
+    },
+    categoryFilter: {
+      type: Boolean,
+      required: false,
+      default: true,
+    },
+    tagFilter: {
+      type: Boolean,
+      required: false,
+      default: true,
+    },
+  },
+
+  computed: {
+    filteredPosts () {
+      let filteredPosts = this.$posts
+
+      if (this.filterCategory) {
+        filteredPosts = filteredPosts.filter(p => p.category === this.filterCategory)
+      }
+
+      if (this.filterTags.length !== 0) {
+        filteredPosts = filteredPosts.filter(p => {
+          const postTags = p.tags
+          for (const tag of this.filterTags) {
+            if (postTags.includes(tag)) {
+              return true
+            }
+          }
+          return false
+        })
+      }
+
+      if (this.filterSearch !== '') {
+        const searchString = this.filterSearch.toLowerCase().trim()
+        const match = item => {
+          if (typeof item === 'string') {
+            return item.toLowerCase().includes(searchString)
+          }
+
+          if (Array.isArray(item)) {
+            return item.map(i => match(i)).includes(true)
+          }
+
+          return false
+        }
+        filteredPosts = filteredPosts.filter(p =>
+          match(p.title) ||
+          match(p.excerpt) ||
+          match(p.frontmatter.description) ||
+          match(p.tags) ||
+          match(p.category)
+        )
+      }
+
+      return filteredPosts
+    },
+  },
+}
+</script>
+
+<style lang="stylus">
+@require '~@theme/styles/variables'
+
+.filter-categories,
+.filter-tags
+  a
+    color $textColor
+</style>
+
+<style lang="stylus" scoped>
+@require '~@theme/styles/variables'
+
+.no-posts
+  color $grayTextColor
+</style>

--- a/lib/components/PostsMain.vue
+++ b/lib/components/PostsMain.vue
@@ -108,7 +108,7 @@ export default {
 
   computed: {
     filteredPosts () {
-      let filteredPosts = this.$posts
+      let filteredPosts = this.posts || this.$posts
 
       if (this.filterCategory) {
         filteredPosts = filteredPosts.filter(p => p.category === this.filterCategory)

--- a/lib/layouts/Category.vue
+++ b/lib/layouts/Category.vue
@@ -1,20 +1,35 @@
 <template>
   <div class="category">
-    <PostsMain
+    <PostsFilter
+      v-model="posts"
       :posts="$category.posts"
-      :category-filter="false"
+      :categories="false"
     />
+
+    <PostsList :posts="posts" />
   </div>
 </template>
 
 <script>
-import PostsMain from '../components/PostsMain.vue'
+import PostsFilter from '../components/PostsFilter.vue'
+import PostsList from '../components/PostsList.vue'
 
 export default {
   name: 'Category',
 
   components: {
-    PostsMain,
+    PostsFilter,
+    PostsList,
+  },
+
+  data () {
+    return {
+      posts: null,
+    }
+  },
+
+  created () {
+    this.posts = this.$category.posts
   },
 }
 </script>

--- a/lib/layouts/Category.vue
+++ b/lib/layouts/Category.vue
@@ -1,20 +1,20 @@
 <template>
   <div class="category">
-    <PostsList
-      class="main-div"
+    <PostsMain
       :posts="$category.posts"
+      :category-filter="false"
     />
   </div>
 </template>
 
 <script>
-import PostsList from '../components/PostsList.vue'
+import PostsMain from '../components/PostsMain.vue'
 
 export default {
   name: 'Category',
 
   components: {
-    PostsList,
+    PostsMain,
   },
 }
 </script>

--- a/lib/layouts/Home.vue
+++ b/lib/layouts/Home.vue
@@ -1,20 +1,17 @@
 <template>
   <div class="home">
-    <PostsMain
-      :category-filter="false"
-      :tag-filter="false"
-    />
+    <PostsList />
   </div>
 </template>
 
 <script>
-import PostsMain from '../components/PostsMain.vue'
+import PostsList from '../components/PostsList.vue'
 
 export default {
   name: 'Home',
 
   components: {
-    PostsMain,
+    PostsList,
   },
 }
 </script>

--- a/lib/layouts/Home.vue
+++ b/lib/layouts/Home.vue
@@ -1,17 +1,20 @@
 <template>
   <div class="home">
-    <PostsList class="main-div" />
+    <PostsMain
+      :category-filter="false"
+      :tag-filter="false"
+    />
   </div>
 </template>
 
 <script>
-import PostsList from '../components/PostsList.vue'
+import PostsMain from '../components/PostsMain.vue'
 
 export default {
   name: 'Home',
 
   components: {
-    PostsList,
+    PostsMain,
   },
 }
 </script>

--- a/lib/layouts/Posts.vue
+++ b/lib/layouts/Posts.vue
@@ -16,29 +16,11 @@
       </h3>
 
       <PostsFilterTags v-model="filterTags" />
-
-      <h3 class="filter-search">
-        {{ $themeConfig.lang.search }}
-      </h3>
-
-      <PostsFilterSearch v-model="filterSearch" />
     </div>
 
-    <div class="main-div">
-      <TransitionFadeSlide>
-        <div
-          v-if="filteredPosts.length ===0"
-          class="no-posts"
-        >
-          {{ $themeConfig.lang.noRelatedPosts }}
-        </div>
-
-        <PostsList
-          v-else
-          :posts="filteredPosts"
-        />
-      </TransitionFadeSlide>
-    </div>
+    <PostsList
+      :posts="filteredPosts"
+    />
   </div>
 </template>
 
@@ -46,8 +28,6 @@
 import PostsList from '../components/PostsList.vue'
 import PostsFilterCategories from '../components/PostsFilterCategories.vue'
 import PostsFilterTags from '../components/PostsFilterTags.vue'
-import PostsFilterSearch from '../components/PostsFilterSearch.vue'
-import TransitionFadeSlide from '../components/TransitionFadeSlide.vue'
 
 export default {
   name: 'Posts',
@@ -56,15 +36,12 @@ export default {
     PostsList,
     PostsFilterCategories,
     PostsFilterTags,
-    PostsFilterSearch,
-    TransitionFadeSlide,
   },
 
   data () {
     return {
       filterTags: [],
       filterCategory: null,
-      filterSearch: '',
     }
   },
 
@@ -88,28 +65,6 @@ export default {
         })
       }
 
-      if (this.filterSearch !== '') {
-        const searchString = this.filterSearch.toLowerCase().trim()
-        const match = item => {
-          if (typeof item === 'string') {
-            return item.toLowerCase().includes(searchString)
-          }
-
-          if (Array.isArray(item)) {
-            return item.map(i => match(i)).includes(true)
-          }
-
-          return false
-        }
-        filteredPosts = filteredPosts.filter(p =>
-          match(p.title) ||
-          match(p.excerpt) ||
-          match(p.frontmatter.description) ||
-          match(p.tags) ||
-          match(p.category)
-        )
-      }
-
       return filteredPosts
     },
   },
@@ -123,11 +78,4 @@ export default {
 .filter-tags
   a
     color $textColor
-</style>
-
-<style lang="stylus" scoped>
-@require '~@theme/styles/variables'
-
-.no-posts
-  color $grayTextColor
 </style>

--- a/lib/layouts/Posts.vue
+++ b/lib/layouts/Posts.vue
@@ -1,19 +1,34 @@
 <template>
   <div class="posts">
-    <PostsMain
-      :posts="this.$posts"
+    <PostsFilter
+      v-model="posts"
+      :posts="$posts"
     />
+
+    <PostsList :posts="posts" />
   </div>
 </template>
 
 <script>
-import PostsMain from '../components/PostsMain.vue'
+import PostsFilter from '../components/PostsFilter.vue'
+import PostsList from '../components/PostsList.vue'
 
 export default {
   name: 'Posts',
 
   components: {
-    PostsMain,
+    PostsFilter,
+    PostsList,
+  },
+
+  data () {
+    return {
+      posts: null,
+    }
+  },
+
+  created () {
+    this.posts = this.$posts
   },
 }
 </script>

--- a/lib/layouts/Posts.vue
+++ b/lib/layouts/Posts.vue
@@ -1,81 +1,19 @@
 <template>
   <div class="posts">
-    <div class="main-div">
-      <h3 class="filter-categories">
-        <RouterLink to="/posts/categories/">
-          {{ $themeConfig.lang.categories }}
-        </RouterLink>
-      </h3>
-
-      <PostsFilterCategories v-model="filterCategory" />
-
-      <h3 class="filter-tags">
-        <RouterLink to="/posts/tags/">
-          {{ $themeConfig.lang.tags }}
-        </RouterLink>
-      </h3>
-
-      <PostsFilterTags v-model="filterTags" />
-    </div>
-
-    <PostsList
-      :posts="filteredPosts"
+    <PostsMain
+      :posts="this.$posts"
     />
   </div>
 </template>
 
 <script>
-import PostsList from '../components/PostsList.vue'
-import PostsFilterCategories from '../components/PostsFilterCategories.vue'
-import PostsFilterTags from '../components/PostsFilterTags.vue'
+import PostsMain from '../components/PostsMain.vue'
 
 export default {
   name: 'Posts',
 
   components: {
-    PostsList,
-    PostsFilterCategories,
-    PostsFilterTags,
-  },
-
-  data () {
-    return {
-      filterTags: [],
-      filterCategory: null,
-    }
-  },
-
-  computed: {
-    filteredPosts () {
-      let filteredPosts = this.$posts
-
-      if (this.filterCategory) {
-        filteredPosts = filteredPosts.filter(p => p.category === this.filterCategory)
-      }
-
-      if (this.filterTags.length !== 0) {
-        filteredPosts = filteredPosts.filter(p => {
-          const postTags = p.tags
-          for (const tag of this.filterTags) {
-            if (postTags.includes(tag)) {
-              return true
-            }
-          }
-          return false
-        })
-      }
-
-      return filteredPosts
-    },
+    PostsMain,
   },
 }
 </script>
-
-<style lang="stylus">
-@require '~@theme/styles/variables'
-
-.filter-categories,
-.filter-tags
-  a
-    color $textColor
-</style>

--- a/lib/layouts/Tag.vue
+++ b/lib/layouts/Tag.vue
@@ -1,20 +1,20 @@
 <template>
   <div class="tag">
-    <PostsList
-      class="main-div"
+    <PostsMain
       :posts="$tag.posts"
+      :tag-filter="false"
     />
   </div>
 </template>
 
 <script>
-import PostsList from '../components/PostsList.vue'
+import PostsMain from '../components/PostsMain.vue'
 
 export default {
   name: 'Tag',
 
   components: {
-    PostsList,
+    PostsMain,
   },
 }
 </script>

--- a/lib/layouts/Tag.vue
+++ b/lib/layouts/Tag.vue
@@ -1,20 +1,35 @@
 <template>
   <div class="tag">
-    <PostsMain
+    <PostsFilter
+      v-model="posts"
       :posts="$tag.posts"
-      :tag-filter="false"
+      :tags="false"
     />
+
+    <PostsList :posts="posts" />
   </div>
 </template>
 
 <script>
-import PostsMain from '../components/PostsMain.vue'
+import PostsFilter from '../components/PostsFilter.vue'
+import PostsList from '../components/PostsList.vue'
 
 export default {
   name: 'Tag',
 
   components: {
-    PostsMain,
+    PostsFilter,
+    PostsList,
+  },
+
+  data () {
+    return {
+      posts: null,
+    }
+  },
+
+  created () {
+    this.posts = this.$tag.posts
   },
 }
 </script>


### PR DESCRIPTION
Hello, 

In my project i will use the specific category pages for post types separation.
So, my menu contains routes to /posts/categories/{category} (i.e. /blog, /example, /functions).

then, i included search on this layouts.

You think it´s a valid feature to master?

if not, just ignore me. no problems.