### PR TITLE
fix: remove extra margin before the first child of a post list

### DIFF
--- a/lib/components/PostsListItem.vue
+++ b/lib/components/PostsListItem.vue
@@ -84,6 +84,9 @@ export default {
 
 .posts-list-item
   padding 0 0.5rem
+  &:first-child
+    h3
+      margin-top 0
   &:not(:first-child)
     border-top 1px solid $borderColor
   .post-title


### PR DESCRIPTION
~~发这个 PR 主要是为了混脸熟~~
```stylus
.main-div
  > :first-child
    margin-top 0
```
之前的这个样式并没有什么卵用，因为 `<h3>` 是位于 first child 内部的。