### PR TITLE
fix: overflow of post-nav-toc

### DIFF
--- a/lib/components/PostNavCard.vue
+++ b/lib/components/PostNavCard.vue
@@ -109,6 +109,7 @@ export default {
   color $grayTextColor
   word-break break-all
   line-height 160%
+  overflow-y auto
   .icon
     fill $grayTextColor
   .post-nav-toc > ul
@@ -116,7 +117,6 @@ export default {
       margin 0.5rem 0
       padding-left 2rem
       max-height calc(100vh - 16rem)
-      overflow auto
       &::-webkit-scrollbar
         width 0 !important
       ul

--- a/lib/components/PostNavCard.vue
+++ b/lib/components/PostNavCard.vue
@@ -116,7 +116,7 @@ export default {
       margin 0.5rem 0
       padding-left 2rem
       max-height calc(100vh - 16rem)
-      overflow hidden
+      overflow auto
       &::-webkit-scrollbar
         width 0 !important
       ul

--- a/lib/components/PostNavCard.vue
+++ b/lib/components/PostNavCard.vue
@@ -116,9 +116,7 @@ export default {
       margin 0.5rem 0
       padding-left 2rem
       max-height calc(100vh - 16rem)
-      overflow-y scroll
-      overflow -moz-scrollbars-none
-      -ms-overflow-style none
+      overflow hidden
       &::-webkit-scrollbar
         width 0 !important
       ul

--- a/lib/components/PostNavCard.vue
+++ b/lib/components/PostNavCard.vue
@@ -116,7 +116,9 @@ export default {
     margin 0.5rem 0
     padding-left 2rem
     max-height calc(100vh - 16rem)
-    overflow hidden auto
+    // separate overflow to be compatible with Safari
+    overflow-x hidden
+    overflow-y auto
     scrollbar-width thin
     &::-webkit-scrollbar
       width 3px

--- a/lib/components/PostNavCard.vue
+++ b/lib/components/PostNavCard.vue
@@ -109,18 +109,23 @@ export default {
   color $grayTextColor
   word-break break-all
   line-height 160%
-  overflow-y auto
   .icon
     fill $grayTextColor
   .post-nav-toc > ul
-      word-break normal
-      margin 0.5rem 0
-      padding-left 2rem
-      max-height calc(100vh - 16rem)
-      &::-webkit-scrollbar
-        width 0 !important
-      ul
-        padding-left 0.8rem
+    word-break normal
+    margin 0.5rem 0
+    padding-left 2rem
+    max-height calc(100vh - 16rem)
+    overflow hidden auto
+    scrollbar-width thin
+    &::-webkit-scrollbar
+      width 3px
+    &::-webkit-scrollbar-track
+      background-color $borderColor
+    &::-webkit-scrollbar-thumb
+      background-color $lightTextColor
+    ul
+      padding-left 0.8rem
   .post-nav-comments a
     color $grayTextColor
     &:hover


### PR DESCRIPTION
Scrollbar is displayed because the value of `overflow-y` is `scroll`.

https://github.com/meteorlxy/vuepress-theme-meteorlxy/blob/c7e83222923227a8f0e4e9a718ceadb9f4d20362/lib/components/PostNavCard.vue#L119-L121

Also, `overflow` is available for most browsers.
So I think that it is not a problem to put them together.
(ref: [Can I use - css-overflow](https://caniuse.com/#feat=css-overflow))

## Reference
MDN: [overflow](https://developer.mozilla.org/ja/docs/Web/CSS/overflow), [overflow-y](https://developer.mozilla.org/ja/docs/Web/CSS/overflow-y), [-ms-overflow-style](https://developer.mozilla.org/ja/docs/Web/CSS/-ms-overflow-style)