### PR TITLE
feat:social media icon display enhance

### DIFF
--- a/lib/components/IconSns.vue
+++ b/lib/components/IconSns.vue
@@ -97,7 +97,7 @@ export default {
 <style lang="stylus">
 @require '~@theme/styles/variables'
 
-.sns-link
+.sns-link-vtm
   margin 0 0.1em
   .sns-icon
     color $grayTextColor

--- a/lib/components/InfoCard.vue
+++ b/lib/components/InfoCard.vue
@@ -67,7 +67,7 @@
           v-for="(item, name) of sns"
           :key="name"
           :href="item.link"
-          class="sns-link"
+          class="sns-link-vtm"
           target="_blank"
         >
           <IconSns

--- a/lib/components/TheFooter.vue
+++ b/lib/components/TheFooter.vue
@@ -7,7 +7,7 @@
       <a
         v-for="(item, name) in sns"
         :key="name"
-        class="sns-link"
+        class="sns-link-vtm"
         :href="item.link"
         target="_blank"
       >


### PR DESCRIPTION
[关于社交媒体图标被广告拦截插件屏蔽的优化](https://github.com/meteorlxy/vuepress-theme-meteorlxy/issues/81)